### PR TITLE
Call callback when clearing an empty cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ RedisStore.prototype.set = function set(key, val, ttl, fn) {
     if (err) return fn(err);
     fn(null, val);
   }
-  
+
 };
 
 /**
@@ -121,10 +121,11 @@ RedisStore.prototype.clear = function clear(key, fn) {
   }
 
   fn = fn || noop;
-  
+
   store.client.keys(key + '*', function keys(err, data) {
     if (err) return fn(err);
     var count = data.length;
+    if (count === 0) return fn(null, null);
     data.forEach(function each(key) {
       store.del(key, function del(err, data) {
         if (err) {

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ var assert = require('assert')
 describe('cacheman-redis', function () {
 
   before(function(done){
-    cache = new Cache({}, {});
+    cache = new Cache({ port: 6379, host: 'localhost' }, {});
     done();
   });
 
@@ -20,7 +20,7 @@ describe('cacheman-redis', function () {
     assert.ok(cache.del);
     assert.ok(cache.clear);
   });
-    
+
   it('should store items', function (done) {
     cache.set('test1', { a: 1 }, function (err) {
       if (err) return done(err);
@@ -128,6 +128,12 @@ describe('cacheman-redis', function () {
           done();
         });
       }, 1000);
+    });
+  });
+
+  it('should clear an empty cache', function(done) {
+    cache.clear('no-entries', function(err, data) {
+      done();
     });
   });
 


### PR DESCRIPTION
The `clear` method was not calling the `fn` callback if there were no keys to delete.  This fixes that.
