### PR TITLE
Call callback if no keys are found to delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ RedisStore.prototype.clear = function clear(key, fn) {
   store.client.keys(key + '*', function keys(err, data) {
     if (err) return fn(err);
     var count = data.length;
+    if (count === 0) return fn(null, null);
     data.forEach(function each(key) {
       store.del(key, function del(err, data) {
         if (err) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,14 @@ module.exports = RedisStore;
 function RedisStore(options, bucket) {
   options = options || {};
   this.bucket = bucket || {};
-  this.client = options.client || new redis.createClient(options.port, options.host, options);
+  if (options.client) {
+    this.client = options.client;
+  } else if (!options.port && !options.host) {
+    this.client = new redis.createClient();
+  } else {
+    this.client = new redis.createClient(options.port, options.host, options);
+  }
+
   if (options.password) {
     this.client.auth(options.password, function auth(err){
       if (err) throw err;

--- a/test/test.js
+++ b/test/test.js
@@ -131,4 +131,10 @@ describe('cacheman-redis', function () {
     });
   });
 
+  it('should clear an empty cache', function(done) {
+    cache.clear('no-entries', function(err, data) {
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
The `clear` method was not calling the `fn` callback if there were no keys to delete. This fixes that.