### PR TITLE
Enhance del command and update es6 style.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,8 +50,6 @@ export default class RedisStore {
         if (err) throw err;
       });
     }
-
-    this.prefix = options.prefix || 'cacheman:';
   }
 
   /**
@@ -63,8 +61,8 @@ export default class RedisStore {
    */
 
   get(key, fn = noop) {
-    const k = this.prefix + key;
-    this.client.get(k, (err, data) => {
+
+    this.client.get(key, (err, data) => {
       if (err) return fn(err);
       if (!data) return fn(null, null);
       data = data.toString();
@@ -87,7 +85,6 @@ export default class RedisStore {
    */
 
   set(key, val, ttl, fn = noop) {
-    const k = this.prefix + key;
 
     if ('function' === typeof ttl) {
       fn = ttl;
@@ -106,9 +103,9 @@ export default class RedisStore {
     }
 
     if (-1 === ttl) {
-      this.client.set(k, val, cb);
+      this.client.set(key, val, cb);
     } else {
-      this.client.setex(k, (ttl || 60), val, cb);
+      this.client.setex(key, (ttl || 60), val, cb);
     }
   }
 
@@ -148,7 +145,7 @@ export default class RedisStore {
    */
 
   del(key, fn = noop) {
-    this._del(this.prefix + key, fn);
+    this._del(key, fn);
   }
 
   /**
@@ -159,7 +156,13 @@ export default class RedisStore {
    * @api public
    */
 
-  clear(fn = noop) {
-    this._del(this.prefix + '*', fn);
+  clear(key = '', fn = noop) {
+
+    if ('function' === typeof key) {
+      fn = key;
+      key = '';
+    }
+
+    this._del(`${key}*`, fn);
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ export default class RedisStore {
    */
 
   get(key, fn = noop) {
-    let k = this.prefix + key;
+    const k = this.prefix + key;
     this.client.get(k, (err, data) => {
       if (err) return fn(err);
       if (!data) return fn(null, null);
@@ -87,7 +87,7 @@ export default class RedisStore {
    */
 
   set(key, val, ttl, fn = noop) {
-    let k = this.prefix + key;
+    const k = this.prefix + key;
 
     if ('function' === typeof ttl) {
       fn = ttl;
@@ -100,43 +100,30 @@ export default class RedisStore {
       return fn(e);
     }
 
+    const cb = (err) => {
+      if (err) return fn(err);
+      fn(null, val);
+    }
+
     if (-1 === ttl) {
       this.client.set(k, val, cb);
     } else {
       this.client.setex(k, (ttl || 60), val, cb);
     }
-
-    function cb(err) {
-      if (err) return fn(err);
-      fn(null, val);
-    }
-    
   }
 
   /**
-   * Delete an entry.
+   * Delete entry. Supported glob-style patterns.
    *
    * @param {String} key
    * @param {Function} fn
-   * @api public
+   * @api private
    */
 
-  del(key, fn = noop) {
-    this.client.del(this.prefix + key, fn);
-  }
-
-  /**
-   * Clear all entries for this key in cache.
-   *
-   * @param {String} key
-   * @param {Function} fn
-   * @api public
-   */
-
-  clear(fn = noop) {
-    this.client.keys(this.prefix + '*', (err, data) => {
+  _del(key, fn = noop) {
+    this.client.keys(key, (err, data) => {
       if (err) return fn(err);
-      var count = data.length;
+      let count = data.length;
       if (count === 0) return fn(null, null);
       data.forEach((key) => {
         this.client.del(key, (err, data) => {
@@ -150,5 +137,29 @@ export default class RedisStore {
         });
       });
     });
+  }
+
+  /**
+   * Delete an entry (Supported glob-style patterns).
+   *
+   * @param {String} key
+   * @param {Function} fn
+   * @api public
+   */
+
+  del(key, fn = noop) {
+    this._del(this.prefix + key, fn);
+  }
+
+  /**
+   * Clear all entries for this key in cache.
+   *
+   * @param {String} key
+   * @param {Function} fn
+   * @api public
+   */
+
+  clear(fn = noop) {
+    this._del(this.prefix + '*', fn);
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,33 +1,33 @@
+import 'babel/polyfill';
 import assert from 'assert';
 import redis from 'redis';
 import Cache from '../lib/index';
 
-
 const uri = 'redis://127.0.0.1:6379';
 let cache;
 
-describe('cacheman-redis', function () {
+describe('cacheman-redis', () => {
 
-  before(function(done){
+  before((done) => {
     cache = new Cache({}, {});
     done();
   });
 
-  after(function(done){
+  after((done) => {
     cache.clear(done);
   });
 
-  it('should have main methods', function () {
+  it('should have main methods', () => {
     assert.ok(cache.set);
     assert.ok(cache.get);
     assert.ok(cache.del);
     assert.ok(cache.clear);
   });
-    
-  it('should store items', function (done) {
-    cache.set('test1', { a: 1 }, function (err) {
+
+  it('should store items', (done) => {
+    cache.set('test1', { a: 1 }, (err) => {
       if (err) return done(err);
-      cache.get('test1', function (err, data) {
+      cache.get('test1', (err, data) => {
         if (err) return done(err);
         assert.equal(data.a, 1);
         done();
@@ -35,10 +35,10 @@ describe('cacheman-redis', function () {
     });
   });
 
-  it('should store zero', function (done) {
-    cache.set('test2', 0, function (err) {
+  it('should store zero', (done) => {
+    cache.set('test2', 0, (err) => {
       if (err) return done(err);
-      cache.get('test2', function (err, data) {
+      cache.get('test2', (err, data) => {
         if (err) return done(err);
         assert.strictEqual(data, 0);
         done();
@@ -46,10 +46,10 @@ describe('cacheman-redis', function () {
     });
   });
 
-  it('should store false', function (done) {
-    cache.set('test3', false, function (err) {
+  it('should store false', (done) => {
+    cache.set('test3', false, (err) => {
       if (err) return done(err);
-      cache.get('test3', function (err, data) {
+      cache.get('test3', (err, data) => {
         if (err) return done(err);
         assert.strictEqual(data, false);
         done();
@@ -57,10 +57,10 @@ describe('cacheman-redis', function () {
     });
   });
 
-  it('should store null', function (done) {
-    cache.set('test4', null, function (err) {
+  it('should store null', (done) => {
+    cache.set('test4', null, (err) => {
       if (err) return done(err);
-      cache.get('test4', function (err, data) {
+      cache.get('test4', (err, data) => {
         if (err) return done(err);
         assert.strictEqual(data, null);
         done();
@@ -68,16 +68,16 @@ describe('cacheman-redis', function () {
     });
   });
 
-  it('should delete items', function (done) {
+  it('should delete items', (done) => {
     let value = Date.now();
-    cache.set('test5', value, function (err) {
+    cache.set('test5', value, (err) => {
       if (err) return done(err);
-      cache.get('test5', function (err, data) {
+      cache.get('test5', (err, data) => {
         if (err) return done(err);
         assert.equal(data, value);
-        cache.del('test5', function (err) {
+        cache.del('test5', (err) => {
           if (err) return done(err);
-          cache.get('test5', function (err, data) {
+          cache.get('test5', (err, data) => {
             if (err) return done(err);
             assert.equal(data, null);
             done();
@@ -87,16 +87,42 @@ describe('cacheman-redis', function () {
     });
   });
 
-  it('should clear items', function (done) {
+  it('should delete items with glob-style patterns', (done) => {
     let value = Date.now();
-    cache.set('test6', value, function (err) {
-      if (err) return done(err);
-      cache.get('test6', function (err, data) {
+
+    Promise.all([
+      cache.set('foo_1', value),
+      cache.set('foo_2', value)
+    ]).then(() => {
+      cache.get('foo_1', (err, data) => {
         if (err) return done(err);
         assert.equal(data, value);
-        cache.clear(function (err) {
+        cache.del('foo*', (err) => {
           if (err) return done(err);
-          cache.get('test6', function (err, data) {
+          cache.get('foo_1', (err, data) => {
+            if (err) return done(err);
+            assert.equal(data, null);
+            cache.get('foo_2', (err, data) => {
+              if (err) return done(err);
+              assert.equal(data, null);
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it('should clear items', (done) => {
+    let value = Date.now();
+    cache.set('test6', value, (err) => {
+      if (err) return done(err);
+      cache.get('test6', (err, data) => {
+        if (err) return done(err);
+        assert.equal(data, value);
+        cache.clear((err) => {
+          if (err) return done(err);
+          cache.get('test6', (err, data) => {
             if (err) return done(err);
             assert.equal(data, null);
             done();
@@ -108,10 +134,10 @@ describe('cacheman-redis', function () {
 
   it('should expire key', function (done) {
     this.timeout(0);
-    cache.set('test7', { a: 1 }, 1, function (err) {
+    cache.set('test7', { a: 1 }, 1, (err) => {
       if (err) return done(err);
-      setTimeout(function () {
-        cache.get('test7', function (err, data) {
+      setTimeout(() => {
+        cache.get('test7', (err, data) => {
         if (err) return done(err);
           assert.equal(data, null);
           done();
@@ -122,10 +148,10 @@ describe('cacheman-redis', function () {
 
   it('should not expire key', function (done) {
     this.timeout(0);
-    cache.set('test8', { a: 1 }, -1, function (err) {
+    cache.set('test8', { a: 1 }, -1, (err) => {
       if (err) return done(err);
-      setTimeout(function () {
-        cache.get('test8', function (err, data) {
+      setTimeout(() => {
+        cache.get('test8', (err, data) => {
         if (err) return done(err);
           assert.deepEqual(data, { a: 1 });
           done();
@@ -134,16 +160,16 @@ describe('cacheman-redis', function () {
     });
   });
 
-  it('should get the same value subsequently', function(done) {
+  it('should get the same value subsequently', (done) => {
     let val = 'Test Value';
-    cache.set('test', 'Test Value', function() {
-      cache.get('test', function(err, data) {
+    cache.set('test', 'Test Value', () => {
+      cache.get('test', (err, data) => {
         if (err) return done(err);
         assert.strictEqual(data, val);
-        cache.get('test', function(err, data) {
+        cache.get('test', (err, data) => {
           if (err) return done(err);
           assert.strictEqual(data, val);
-          cache.get('test', function(err, data) {
+          cache.get('test', (err, data) => {
             if (err) return done(err);
              assert.strictEqual(data, val);
              done();
@@ -153,12 +179,11 @@ describe('cacheman-redis', function () {
     });
   });
 
-
-  it('should allow passing redis connection string', function (done) {
+  it('should allow passing redis connection string', (done) => {
     cache = new Cache(uri);
-    cache.set('test9', { a: 1 }, function (err) {
+    cache.set('test9', { a: 1 }, (err) => {
       if (err) return done(err);
-      cache.get('test9', function (err, data) {
+      cache.get('test9', (err, data) => {
         if (err) return done(err);
         assert.equal(data.a, 1);
         done();
@@ -166,12 +191,12 @@ describe('cacheman-redis', function () {
     });
   });
 
-  it('should allow passing redis client as first argument', function (done) {
+  it('should allow passing redis client as first argument', (done) => {
     let client = redis.createClient();
     cache = new Cache(client);
-    cache.set('test10', { a: 1 }, function (err) {
+    cache.set('test10', { a: 1 }, (err) => {
       if (err) return done(err);
-      cache.get('test10', function (err, data) {
+      cache.get('test10', (err, data) => {
         if (err) return done(err);
         assert.equal(data.a, 1);
         done();
@@ -179,12 +204,12 @@ describe('cacheman-redis', function () {
     });
   });
 
-  it('should allow passing redis client as client in options', function (done) {
+  it('should allow passing redis client as client in options', (done) => {
     let client = redis.createClient();
     cache = new Cache({ client: client });
-    cache.set('test11', { a: 1 }, function (err) {
+    cache.set('test11', { a: 1 }, (err) => {
       if (err) return done(err);
-      cache.get('test11', function (err, data) {
+      cache.get('test11', (err, data) => {
         if (err) return done(err);
         assert.equal(data.a, 1);
         done();
@@ -192,8 +217,8 @@ describe('cacheman-redis', function () {
     });
   });
 
-  it('should clear an empty cache', function(done) {
-    cache.clear(function(err, data) {
+  it('should clear an empty cache', (done) => {
+    cache.clear((err, data) => {
       done();
     });
   });


### PR DESCRIPTION
Support delete cache with glob-style patterns.

ref: http://redis.io/commands/KEYS

And missing first parameter as key on `clear` method. 

ref: https://github.com/cayasso/cacheman/blob/master/lib%2Findex.js#L296

cc @cayasso 