### PR TITLE
remove prefix on redis options.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,14 @@ export default class RedisStore {
     }  else if (!options.port && !options.host) {
       this.client = new redis.createClient();
     } else {
-      this.client = new redis.createClient(options.port, options.host, options);
+      const clientOptions = Object.assign({}, options);
+
+      // node redis support prefix key since v2.4.0 version.
+      if (clientOptions.hasOwnProperty('prefix')) {
+        delete clientOptions.prefix;
+      }
+
+      this.client = new redis.createClient(clientOptions.port, clientOptions.host, clientOptions);
     }
 
     if (options.password) {

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ let cache;
 describe('cacheman-redis', () => {
 
   before((done) => {
-    cache = new Cache({}, {});
+    cache = new Cache();
     done();
   });
 


### PR DESCRIPTION
Hi @cayasso 

Node redis support prefix key since [2.4.0 version](https://github.com/NodeRedis/node_redis/releases). The following config will output different key between `2.4.x` and `2.3.x` version.

```javascript
var cache = new Cacheman({
  host: '127.0.0.1',
  port: '6379',
  prefix: 'mcs',
  engine: 'redis'
});
```

The redis key prefix is `cache:mcs` on redis `2.3.x` but `cachecache:mcs` on `2.4.x` version. We need remove `prefix` option on redis config.

Reference issue: https://github.com/appleboy/cacheman-promise/issues/13