### PR TITLE
Fixing constructor when argument is redis uri string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 sudo: false
 language: node_js
 node_js:
+  - "8"
+  - "6"
   - "4"
-  - "3"
-  - "2"
-  - "1"
-  - "0.12"
-  - "0.10"
 services:
   - redis
 before_install:

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,7 @@ clean:
 	rm -rf node/
 
 test:
-	@./node_modules/.bin/mocha \
-		--require babel-core/register \
-		--reporter spec \
-		--recursive \
-		test
+	@./node_modules/.bin/mocha test
+
 
 .PHONY: all clean test node

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,12 +24,11 @@ export default class RedisStore {
    */
 
   constructor(options = {}) {
-
-    const { port, host, client, setex, password, database, prefix } = options;
- 
     if ('string' === typeof options) {
       options = parse(options);
     }
+
+    const { port, host, client, setex, password, database, prefix } = options;
 
     if ('function' === typeof setex) {
       this.client = options;

--- a/test/index.js
+++ b/test/index.js
@@ -185,9 +185,9 @@ describe('cacheman-redis', () => {
 
   it('should allow passing redis connection params as object', (done) => {
     cache = new Cache(connection);
-    cache.set('test12', { a: 1 }, (err) => {
+    cache.set('test9', { a: 1 }, (err) => {
       if (err) return done(err);
-      cache.get('test12', (err, data) => {
+      cache.get('test9', (err, data) => {
         if (err) return done(err);
         assert.equal(data.a, 1);
         assert.equal(cache.client.selected_db, 6);
@@ -198,9 +198,9 @@ describe('cacheman-redis', () => {
 
   it('should allow passing redis connection string', (done) => {
     cache = new Cache(uri);
-    cache.set('test9', { a: 1 }, (err) => {
+    cache.set('test10', { a: 1 }, (err) => {
       if (err) return done(err);
-      cache.get('test9', (err, data) => {
+      cache.get('test10', (err, data) => {
         if (err) return done(err);
         assert.equal(data.a, 1);
         assert.equal(cache.client.selected_db, 5);
@@ -212,9 +212,9 @@ describe('cacheman-redis', () => {
   it('should allow passing redis client as first argument', (done) => {
     let client = redis.createClient();
     cache = new Cache(client);
-    cache.set('test10', { a: 1 }, (err) => {
+    cache.set('test11', { a: 1 }, (err) => {
       if (err) return done(err);
-      cache.get('test10', (err, data) => {
+      cache.get('test11', (err, data) => {
         if (err) return done(err);
         assert.equal(data.a, 1);
         done();
@@ -225,9 +225,9 @@ describe('cacheman-redis', () => {
   it('should allow passing redis client as client in options', (done) => {
     let client = redis.createClient();
     cache = new Cache({ client: client });
-    cache.set('test11', { a: 1 }, (err) => {
+    cache.set('test12', { a: 1 }, (err) => {
       if (err) return done(err);
-      cache.get('test11', (err, data) => {
+      cache.get('test12', (err, data) => {
         if (err) return done(err);
         assert.equal(data.a, 1);
         done();

--- a/test/index.js
+++ b/test/index.js
@@ -2,21 +2,22 @@ import assert from 'assert';
 import redis from 'redis';
 import Cache from '../lib/index';
 
-const uri = 'redis://127.0.0.1:6379';
+const uri = 'redis://127.0.0.1:6379/5';
 const connection = {
   host: '127.0.0.1',
-  port: 6379
-}
-let cache;
+  port: 6379,
+  database: 6
+};
 
 describe('cacheman-redis', () => {
+  let cache = null;
 
-  before((done) => {
+  beforeEach((done) => {
     cache = new Cache();
     done();
   });
 
-  after((done) => {
+  afterEach((done) => {
     cache.clear(done);
   });
 
@@ -182,6 +183,19 @@ describe('cacheman-redis', () => {
     });
   });
 
+  it('should allow passing redis connection params as object', (done) => {
+    cache = new Cache(connection);
+    cache.set('test12', { a: 1 }, (err) => {
+      if (err) return done(err);
+      cache.get('test12', (err, data) => {
+        if (err) return done(err);
+        assert.equal(data.a, 1);
+        assert.equal(cache.client.selected_db, 6);
+        done();
+      });
+    });
+  });
+
   it('should allow passing redis connection string', (done) => {
     cache = new Cache(uri);
     cache.set('test9', { a: 1 }, (err) => {
@@ -189,6 +203,7 @@ describe('cacheman-redis', () => {
       cache.get('test9', (err, data) => {
         if (err) return done(err);
         assert.equal(data.a, 1);
+        assert.equal(cache.client.selected_db, 5);
         done();
       });
     });
@@ -220,21 +235,9 @@ describe('cacheman-redis', () => {
     });
   });
 
-  it('should allow passing redis connection params as object', (done) => {
-    cache = new Cache(connection);
-    cache.set('test12', { a: 1 }, (err) => {
-      if (err) return done(err);
-      cache.get('test12', (err, data) => {
-        if (err) return done(err);
-        assert.equal(data.a, 1);
-        done();
-      });
-    });
-  })
-
   it('should clear an empty cache', (done) => {
     cache.clear((err, data) => {
-      done();
+      done(err);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,10 @@ import redis from 'redis';
 import Cache from '../lib/index';
 
 const uri = 'redis://127.0.0.1:6379';
+const connection = {
+  host: '127.0.0.1',
+  port: 6379
+}
 let cache;
 
 describe('cacheman-redis', () => {
@@ -215,6 +219,18 @@ describe('cacheman-redis', () => {
       });
     });
   });
+
+  it('should allow passing redis connection params as object', (done) => {
+    cache = new Cache(connection);
+    cache.set('test12', { a: 1 }, (err) => {
+      if (err) return done(err);
+      cache.get('test12', (err, data) => {
+        if (err) return done(err);
+        assert.equal(data.a, 1);
+        done();
+      });
+    });
+  })
 
   it('should clear an empty cache', (done) => {
     cache.clear((err, data) => {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,4 @@
---compilers js:babel-core/register
+--require babel-core/register
+--reporter spec
+--recursive
+--exit


### PR DESCRIPTION
1. Fix ability to use connection as uri string
2. Use 3 latest LTS nodejs versions in travis - 4, 6, 8
3. Fix shutdown mocha process after test run