### PR TITLE
Add `scan` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cache.set('my key', { foo: 'bar' }, function (error) {
 
     // delete entry
     cache.del('my key', function (error){
-      
+
       if (error) throw error;
 
       console.log('value deleted');
@@ -48,7 +48,7 @@ cache.set('my key', { foo: 'bar' }, function (error) {
 Create `cacheman-redis` instance. `options` are redis valid options including `port` and `host`.
 
 ```javascript
-var options = { 
+var options = {
   port: 9999,
   host: '127.0.0.1',
   password: 'my-p@ssw0rd'
@@ -128,6 +128,18 @@ cache.clear(function (err) {
   // cache is now clear
 });
 ```
+
+### cache.scan(cursor, count, [fn])
+
+[Scan](https://redis.io/commands/scan) cache from a cursor point and return a count of values
+
+```javascript
+cache.set('foo', { a: 'bar' }, 10, function (err) {
+  cache.scan(0, 10, function (err, result) {
+    console.log(result) // { cursor: 0, entries: [{ key: 'foo', data: { a: 'bar' } }] }
+  });
+});
+````
 
 ## Run tests
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "redis": "^2.8.0"
   },
   "dependencies": {
+    "each": "1.2.1",
     "parse-redis-url": "0.0.2"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@
 
 const redis = require('redis')
 const parser = require('parse-redis-url')
+const each = require('each')
 
 /**
  * Module constants.
@@ -147,6 +148,40 @@ class RedisStore {
             fn(null, null)
           }
         })
+      })
+    })
+  }
+
+  /**
+   * Scan for a number of entries from a cursor point
+   *
+   * @param {Number}   cursor
+   * @param {Number}   fn
+   * @param {Function} fn
+   * @api public
+   */
+
+  scan(cursor, count = 10, fn = noop) {
+    const entries = []
+    const prefix = this.prefix
+    const self = this
+
+    this.client.scan(cursor, 'MATCH', `${prefix}*`, 'COUNT', count, (err, data) => {
+      if (err) return fn(err)
+
+      const [newCursor, keys] = data
+
+      each(keys).call((key, index, next) => {
+        const _key = key.replace(`${this.prefix}`, '')
+
+        self.get(_key, (err, data) => {
+          if (err) return fn(err)
+
+          entries.push({ key: _key, data })
+          next()
+        })
+      }).next(() => {
+        fn(null, { cursor: Number(newCursor), entries })
       })
     })
   }

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ describe('cacheman-redis', () => {
   let cache = null
 
   beforeEach((done) => {
-    cache = new Cache()
+    cache = new Cache({ prefix: 'cacheman-redis:test' })
     done()
   })
 
@@ -26,6 +26,7 @@ describe('cacheman-redis', () => {
     assert.ok(cache.get)
     assert.ok(cache.del)
     assert.ok(cache.clear)
+    assert.ok(cache.scan)
   })
 
   it('should store items', (done) => {
@@ -212,6 +213,42 @@ describe('cacheman-redis', () => {
   it('should clear an empty cache', (done) => {
     cache.clear((err) => {
       done(err)
+    })
+  })
+
+  it('should scan and return results', (done) => {
+    const items = [
+      { key: 'test0',  data: { a: 'test0' } },
+      { key: 'test1',  data: { a: 'test1' } },
+      { key: 'test2',  data: { a: 'test2' } },
+      { key: 'test3',  data: { a: 'test3' } },
+      { key: 'test4',  data: { a: 'test4' } },
+      { key: 'test5',  data: { a: 'test5' } },
+      { key: 'test6',  data: { a: 'test6' } },
+      { key: 'test7',  data: { a: 'test7' } },
+      { key: 'test8',  data: { a: 'test8' } },
+      { key: 'test9',  data: { a: 'test9' } }
+    ]
+
+    const compare = (a, b) => {
+      if (a.key < b.key) return -1
+      else if (a.key > b.key) return 1
+      else return 0;
+    }
+
+    items.forEach((obj, index) => {
+      cache.set(obj.key, obj.data, (err) => {
+        assert.deepEqual(null, err)
+      })
+    })
+
+    cache.scan(0, 20, (err, result) => {
+      assert.deepEqual(null, err)
+      assert.equal(result.cursor, 0)
+
+      const entries = result.entries.sort(compare)
+      assert.deepEqual(items, entries)
+      done()
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,11 @@ double-ended-queue@^2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
 
+each@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/each/-/each-1.2.1.tgz#1ab10811c5141fbb0f8d7ca9b05679b351f70080"
+  integrity sha512-POUbnWaseHgI8I+icHo3jAMrCqoLgVWaI7yqcQ0nat4q2f2BFUVGAndMOvr2UZoHAGAnQqotaM9RI4kZcjtAcg==
+
 escape-string-regexp@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
~- Add `getAll` functionality~
~- Update readme for `getAll` documentation~
- [x] Add `scan` functionality
- [x] Update readme for `scan` documentation

Updated functionality of this pull request to scan the redis cache instead of retrieving all keys. This is due to the usability of the [`redis.keys`](https://redis.io/commands/keys) function.

reference #15 

## Note

While the [redis docs](https://redis.io/commands/scan) can sometimes be confusing for me, here is a nice [example](https://github.com/NodeRedis/node_redis/blob/master/examples/scan.js) of the `scan` usage
